### PR TITLE
new static() is only safe in final classes

### DIFF
--- a/src/Activation.php
+++ b/src/Activation.php
@@ -6,7 +6,7 @@ use PrimeTime\WordPress\PluginControl\DisablePlugins;
 use PrimeTime\WordPress\PluginControl\NetworkEnablePlugins;
 use PrimeTime\WordPress\PluginControl\NetworkDisablePlugins;
 
-class Activation
+final class Activation
 {
     protected $manifest;
 

--- a/src/Activation.php
+++ b/src/Activation.php
@@ -6,7 +6,7 @@ use PrimeTime\WordPress\PluginControl\DisablePlugins;
 use PrimeTime\WordPress\PluginControl\NetworkEnablePlugins;
 use PrimeTime\WordPress\PluginControl\NetworkDisablePlugins;
 
-final class Activation
+class Activation
 {
     protected $manifest;
 
@@ -18,7 +18,7 @@ final class Activation
     public static function set( $config_file, $environment = null )
     {
         $manifest = new Manifest($config_file, $environment);
-        $activation = new static($manifest->load());
+        $activation = new self($manifest->load());
 
         return $activation->apply();
     }


### PR DESCRIPTION
discovered by @phpstan

![image](https://user-images.githubusercontent.com/952007/67031518-03fb0a80-f112-11e9-8c2f-cbeb23da5f21.png)
